### PR TITLE
10 Enforce formatting

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -7,4 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/ruff-action@v1
+      - uses: astral-sh/ruff-action@v3
+        with:
+          args: "format --check"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,6 +12,7 @@
 #
 import os
 import sys
+
 sys.path.insert(0, os.path.abspath(os.path.join('..', '..', 'tcrconvert')))
 
 
@@ -34,7 +35,7 @@ extensions = [
     'sphinx.ext.duration',
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
-    'nbsphinx'
+    'nbsphinx',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/usage_library.ipynb
+++ b/docs/source/usage_library.ipynb
@@ -39,7 +39,9 @@
     "\n",
     "tcr_file = tcrconvert.get_example_path('tenx.csv')\n",
     "\n",
-    "tcrs = pd.read_csv(tcr_file)[['barcode', 'v_gene' , 'd_gene', 'j_gene', 'c_gene', 'cdr3']]\n",
+    "tcrs = pd.read_csv(tcr_file)[\n",
+    "    ['barcode', 'v_gene', 'd_gene', 'j_gene', 'c_gene', 'cdr3']\n",
+    "]\n",
     "tcrs"
    ]
   },
@@ -163,8 +165,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "custom_new = tcrconvert.convert_gene(custom, frm='tenx', to='imgt', quiet=True,\n",
-    "                                     frm_cols=['myVgene', 'myDgene', 'myJgene', 'myCgene'])\n",
+    "custom_new = tcrconvert.convert_gene(\n",
+    "    custom,\n",
+    "    frm='tenx',\n",
+    "    to='imgt',\n",
+    "    quiet=True,\n",
+    "    frm_cols=['myVgene', 'myDgene', 'myJgene', 'myCgene'],\n",
+    ")\n",
     "custom_new"
    ]
   },
@@ -188,8 +195,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "new_tcrs = tcrconvert.convert_gene(tcrs, frm='tenx', to='imgt', quiet=True,\n",
-    "                                   species='rhesus')  # or 'mouse'"
+    "new_tcrs = tcrconvert.convert_gene(\n",
+    "    tcrs, frm='tenx', to='imgt', quiet=True, species='rhesus'\n",
+    ")  # or 'mouse'"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,3 +60,9 @@ docs = [
     "nbsphinx>=0.9.5",
     "ipython>=8.27.0"
     ]
+
+[tool.ruff]
+target-version = "py312"
+
+[tool.ruff.format]
+quote-style = "single"

--- a/tcrconvert/__init__.py
+++ b/tcrconvert/__init__.py
@@ -2,4 +2,4 @@ from .convert import convert_gene
 from .build_lookup import build_lookup_from_fastas
 from .utils import get_example_path
 
-__all__ = ["convert_gene", "build_lookup_from_fastas", "get_example_path"]
+__all__ = ['convert_gene', 'build_lookup_from_fastas', 'get_example_path']

--- a/tcrconvert/build_lookup.py
+++ b/tcrconvert/build_lookup.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 
 def parse_imgt_fasta(infile):
-    '''Extract gene names from a reference FASTA.
+    """Extract gene names from a reference FASTA.
 
     :param infile: Path to FASTA file
     :type infile: str
@@ -33,24 +33,24 @@ def parse_imgt_fasta(infile):
     >>> fasta = tcrconvert.get_example_path('fasta_dir/test_trav.fa')
     >>> tcrconvert.build_lookup.parse_imgt_fasta(fasta)
     ['TRAV1*01', 'TRAV14/DV4*01', 'TRAV38-2/DV8*01']
-    '''
-    
+    """
+
     # Read the file and extract lines starting with ">"
-    with open(infile, "r") as f:
+    with open(infile, 'r') as f:
         lines = f.readlines()
 
     # Extract the second element from lines starting with ">"
     imgt_list = []
     for line in lines:
-        if line.startswith(">"):
-            gene = line.split("|")[1]
+        if line.startswith('>'):
+            gene = line.split('|')[1]
             imgt_list.append(gene)
 
     return imgt_list
 
 
 def extract_imgt_genes(data_dir):
-    '''Extract gene names from all reference FASTA files in a folder.
+    """Extract gene names from all reference FASTA files in a folder.
 
     :param data_dir: Path to directory containing FASTA files
     :type data_dir: str
@@ -79,7 +79,7 @@ def extract_imgt_genes(data_dir):
     2  TRAV38-2/DV8*01
     3  TRBV29/OR9-2*01
     4   TRBVA/OR9-2*01
-    '''
+    """
 
     fastas = []
     for file in os.listdir(data_dir):
@@ -97,7 +97,7 @@ def extract_imgt_genes(data_dir):
 
 
 def add_dash_one(gene_str):
-    '''Add a ``-01`` to genes without IMGT gene-level designation.
+    """Add a ``-01`` to genes without IMGT gene-level designation.
 
     :param gene_str: Gene name
     :type gene_str: str
@@ -109,7 +109,7 @@ def add_dash_one(gene_str):
     >>> import tcrconvert
     >>> tcrconvert.build_lookup.add_dash_one('TRBV2*01')
     'TRBV2-01*01'
-    '''
+    """
 
     if '-' not in gene_str:
         # Add -1 before allele
@@ -118,7 +118,7 @@ def add_dash_one(gene_str):
 
 
 def pad_single_digit(gene_str):
-    '''Add a zero to single-digit gene-level designatinon in gene names.
+    """Add a zero to single-digit gene-level designatinon in gene names.
 
     :param gene_str: Gene name
     :type gene_str: str
@@ -130,7 +130,7 @@ def pad_single_digit(gene_str):
     >>> import tcrconvert
     >>> tcrconvert.build_lookup.pad_single_digit('TCRBV1-2')
     'TCRBV01-2'
-    '''
+    """
 
     # Use regex to find a single digit preceded by letters and followed by a hyphen or asterisk
     updated_string = re.sub(r'([A-Za-z]+)(\d)([-\*])', r'\g<1>0\g<2>\g<3>', gene_str)
@@ -138,7 +138,7 @@ def pad_single_digit(gene_str):
 
 
 def build_lookup_from_fastas(data_dir, species):
-    '''Create these lookup tables from a directory of FASTA files:
+    """Create these lookup tables from a directory of FASTA files:
 
     - lookup.csv
     - lookup_from_tenx.csv
@@ -161,10 +161,10 @@ def build_lookup_from_fastas(data_dir, species):
     >>> import tcrconvert
     >>> fastadir = tcrconvert.get_example_path('fasta_dir') + '/'
     >>> tcrconvert.build_lookup.build_lookup_from_fastas(fastadir, 'rabbit')
-    '''
+    """
 
     # Get the user data directory for saving lookup tables
-    user_dir = platformdirs.user_data_dir("tcrconvert", "Emmma Bishop")
+    user_dir = platformdirs.user_data_dir('tcrconvert', 'Emmma Bishop')
     save_dir = os.path.join(user_dir, species)
     os.makedirs(save_dir, exist_ok=True)
 
@@ -175,25 +175,26 @@ def build_lookup_from_fastas(data_dir, species):
     lookup['tenx'] = lookup['imgt'].apply(lambda x: x[:-3].replace('/DV', 'DV'))
 
     # Create Adaptive columns by adding letters, 0's, removing /DV and renaming /OR
-    lookup['adaptive'] = lookup['imgt'].apply(lambda x: x.\
-                                            replace('TRAV14/DV4', 'TRAV14-1').\
-                                            replace('TRAV23/DV6', 'TRAV23-1').\
-                                            replace('TRAV29/DV5', 'TRAV29-1').\
-                                            replace('TRAV36/DV7', 'TRAV36-1').\
-                                            replace('TRAV38-2/DV8', 'TRAV38-2').\
-                                            replace('TRAV4-4/DV10', 'TRAV4-4/').\
-                                            replace('TRAV6-7/DV9', 'TRAV6-7').\
-                                            replace('TRAV13-4/DV7', 'TRAV13-4').\
-                                            replace('TRAV14D-3/DV8', 'TRAV14D-3').\
-                                            replace('TRAV15D-1/DV6D-1', 'TRAV15D-1').\
-                                            replace('TRAV15-1/DV6-1', 'TRAV15-1').\
-                                            replace('TRAV16D/DV11', 'TRAV16D-1').\
-                                            replace('TRAV21/DV12', 'TRAV21-1').\
-                                            replace('TRAV15-2/DV6-2', 'TRAV15-2').\
-                                            replace('TRAV15D-2/DV6D-2', 'TRAV15D-2').\
-                                            replace('TR', 'TCR').\
-                                            replace('-', '-0').\
-                                            replace('/OR9-02', '-or09_02'))
+    lookup['adaptive'] = lookup['imgt'].apply(
+        lambda x: x.replace('TRAV14/DV4', 'TRAV14-1')
+        .replace('TRAV23/DV6', 'TRAV23-1')
+        .replace('TRAV29/DV5', 'TRAV29-1')
+        .replace('TRAV36/DV7', 'TRAV36-1')
+        .replace('TRAV38-2/DV8', 'TRAV38-2')
+        .replace('TRAV4-4/DV10', 'TRAV4-4/')
+        .replace('TRAV6-7/DV9', 'TRAV6-7')
+        .replace('TRAV13-4/DV7', 'TRAV13-4')
+        .replace('TRAV14D-3/DV8', 'TRAV14D-3')
+        .replace('TRAV15D-1/DV6D-1', 'TRAV15D-1')
+        .replace('TRAV15-1/DV6-1', 'TRAV15-1')
+        .replace('TRAV16D/DV11', 'TRAV16D-1')
+        .replace('TRAV21/DV12', 'TRAV21-1')
+        .replace('TRAV15-2/DV6-2', 'TRAV15-2')
+        .replace('TRAV15D-2/DV6D-2', 'TRAV15D-2')
+        .replace('TR', 'TCR')
+        .replace('-', '-0')
+        .replace('/OR9-02', '-or09_02')
+    )
     lookup['adaptive'] = lookup['adaptive'].apply(lambda x: add_dash_one(x))
     lookup['adaptive'] = lookup['adaptive'].apply(lambda x: pad_single_digit(x))
     lookup['adaptivev2'] = lookup['adaptive']
@@ -209,9 +210,13 @@ def build_lookup_from_fastas(data_dir, species):
     lookup2 = lookup[~lookup.adaptivev2.str.contains('NoData')]
     from_adapt = lookup2[['adaptivev2', 'imgt', 'tenx']]
     from_adapt['adaptive'] = from_adapt['adaptivev2'].apply(lambda x: x[:-3])
-    from_adapt = from_adapt.drop(columns='adaptivev2').groupby('adaptive').first().reset_index()
+    from_adapt = (
+        from_adapt.drop(columns='adaptivev2').groupby('adaptive').first().reset_index()
+    )
     from_adapt['adaptivev2'] = from_adapt['adaptive']
-    from_adaptive = pd.concat([lookup2, from_adapt])[['adaptive', 'adaptivev2', 'imgt', 'tenx']]
+    from_adaptive = pd.concat([lookup2, from_adapt])[
+        ['adaptive', 'adaptivev2', 'imgt', 'tenx']
+    ]
 
     # Remove any duplicate rows
     lookup_path = os.path.join(save_dir, 'lookup.csv')
@@ -227,16 +232,22 @@ def build_lookup_from_fastas(data_dir, species):
 
 # Command-line version of build_lookup_from_fastas()
 @click.command(name='build', no_args_is_help=True)
-@click.option('-i', '--input', help='Path to folder of FASTA files', required=True, type=click.Path(exists=True))
+@click.option(
+    '-i',
+    '--input',
+    help='Path to folder of FASTA files',
+    required=True,
+    type=click.Path(exists=True),
+)
 @click.option('-s', '--species', help='Species name.', required=True)
 def build_lookup_from_fastas_cli(input, species):
-    '''Create lookup tables from within a folder of FASTA files.
+    """Create lookup tables from within a folder of FASTA files.
 
     :Example:
 
     .. code-block:: bash
 
        $ tcrconvert build -i tcrconvert/examples/fasta_dir/ -s rabbit
-    '''
+    """
 
     build_lookup_from_fastas(input, species)

--- a/tcrconvert/cli.py
+++ b/tcrconvert/cli.py
@@ -3,13 +3,13 @@ import click
 from .convert import convert_gene_cli
 from .build_lookup import build_lookup_from_fastas_cli
 
-@click.group(invoke_without_command=True, 
-             no_args_is_help=True)
+
+@click.group(invoke_without_command=True, no_args_is_help=True)
 @click.version_option(version=0.1)
 def entry_point():
-    '''Convert TCR gene names between 10X, Adaptive, and IMGT formats
-    '''
+    """Convert TCR gene names between 10X, Adaptive, and IMGT formats"""
     pass
+
 
 entry_point.add_command(convert_gene_cli)
 entry_point.add_command(build_lookup_from_fastas_cli)

--- a/tcrconvert/convert.py
+++ b/tcrconvert/convert.py
@@ -10,14 +10,16 @@ logging.basicConfig(level=logging.INFO, format='%(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
 
 # Standard column names for different sources of TCR data
-col_ref = {'adaptive': ['v_resolved', 'd_resolved', 'j_resolved'],
-           'adaptivev2': ['vMaxResolved', 'dMaxResolved', 'jMaxResolved'],
-           'imgt': ['v_gene', 'd_gene', 'j_gene', 'c_gene'],
-           'tenx': ['v_gene', 'd_gene', 'j_gene', 'c_gene']}
+col_ref = {
+    'adaptive': ['v_resolved', 'd_resolved', 'j_resolved'],
+    'adaptivev2': ['vMaxResolved', 'dMaxResolved', 'jMaxResolved'],
+    'imgt': ['v_gene', 'd_gene', 'j_gene', 'c_gene'],
+    'tenx': ['v_gene', 'd_gene', 'j_gene', 'c_gene'],
+}
 
 
 def choose_lookup(frm, to, species='human'):
-    '''Determine which lookup table to use and get filepath.
+    """Determine which lookup table to use and get filepath.
 
     :param frm: Input format of TCR data ``['tenx', 'adaptive', 'adaptivev2', 'imgt']``
     :type frm: str
@@ -33,7 +35,7 @@ def choose_lookup(frm, to, species='human'):
     >>> import tcrconvert
     >>> tcrconvert.convert.choose_lookup('imgt', 'adaptive')
     '.../tcrconvert/data/human/lookup.csv'
-    '''
+    """
 
     # Determine where to find lookup tables
     if species in ['human', 'mouse', 'rhesus']:  # Built-in
@@ -46,11 +48,15 @@ def choose_lookup(frm, to, species='human'):
     # Determine which lookup table to use
     if frm == 'tenx':
         lookup_f = os.path.join(species_dir, 'lookup_from_tenx.csv')
-        logger.info('Converting from 10X which lacks allele info. Choosing *01 as allele for all genes.')
+        logger.info(
+            'Converting from 10X which lacks allele info. Choosing *01 as allele for all genes.'
+        )
     elif frm == 'adaptive' or frm == 'adaptivev2':
         lookup_f = os.path.join(species_dir, 'lookup_from_adaptive.csv')
         if to == 'imgt':
-            logger.info('Converting from Adaptive to IMGT. If a gene lacks allele, will choose *01 as allele.')
+            logger.info(
+                'Converting from Adaptive to IMGT. If a gene lacks allele, will choose *01 as allele.'
+            )
     else:
         lookup_f = os.path.join(species_dir, 'lookup.csv')
 
@@ -58,12 +64,14 @@ def choose_lookup(frm, to, species='human'):
     if os.path.exists(lookup_f):
         return lookup_f
     else:
-        logger.error('Lookup table not found, please download IMGT reference FASTAs and run build_lookup_from_fastas()')
-        raise(FileNotFoundError)
+        logger.error(
+            'Lookup table not found, please download IMGT reference FASTAs and run build_lookup_from_fastas()'
+        )
+        raise (FileNotFoundError)
 
 
 def which_frm_cols(df, frm, frm_cols=[]):
-    '''Determine input columns to use for converting gene names.
+    """Determine input columns to use for converting gene names.
 
     :param df: Dataframe containing TCR gene names
     :type df: DataFrame
@@ -82,27 +90,31 @@ def which_frm_cols(df, frm, frm_cols=[]):
     >>> df = pd.read_csv(tcr_file)
     >>> tcrconvert.convert.which_frm_cols(df, 'tenx')
     ['v_gene', 'd_gene', 'j_gene', 'c_gene']
-    '''
+    """
 
     if frm == 'imgt' and not frm_cols:
         cols_from = col_ref['tenx']
-        logger.info(f'No column names provided for IMGT data, will assume 10X column names: {str(cols_from)}')
+        logger.info(
+            f'No column names provided for IMGT data, will assume 10X column names: {str(cols_from)}'
+        )
     if frm_cols:
         missing_cols = set(frm_cols) - set(df.columns)
         if missing_cols:
-            logger.error(f'These columns are not in the input dataframe: {str(missing_cols)}')
-            raise(ValueError)
+            logger.error(
+                f'These columns are not in the input dataframe: {str(missing_cols)}'
+            )
+            raise (ValueError)
         else:
             cols_from = frm_cols
             logger.info(f'Using these custom column names: {str(cols_from)}')
     else:
         cols_from = col_ref[frm]
-    
+
     return cols_from
 
 
 def convert_gene(df, frm, to, species='human', frm_cols=[], quiet=False):
-    '''Convert T-cell receptor V, D, J, and/or C gene names from one naming convention to another.
+    """Convert T-cell receptor V, D, J, and/or C gene names from one naming convention to another.
 
     :param df: Dataframe containing TCR gene names
     :type df: DataFrame
@@ -139,7 +151,7 @@ def convert_gene(df, frm, to, species='human', frm_cols=[], quiet=False):
     2  TCRBV06-04*01  TCRBD02-01*01  TCRBJ02-03*01   <NA>  CASSGVAGGTDTQYF
     3  TCRAV01-02*01  TCRBD01-01*01  TCRAJ33-01*01   <NA>     CAVKDSNYQLIW
     4  TCRBV02-01*01  TCRBD01-01*01  TCRBJ01-02*01   <NA>    CASNQGLNYGYTF
-    '''
+    """
 
     # Set logging level
     if quiet:
@@ -150,14 +162,16 @@ def convert_gene(df, frm, to, species='human', frm_cols=[], quiet=False):
     # Check that input is ok
     if frm == to:
         logger.error('"frm" and "to" formats should be different.')
-        raise(ValueError)
+        raise (ValueError)
     if df.empty:
         logger.error('Input data is empty.')
-        raise(ValueError)
+        raise (ValueError)
 
     # Warn about no Adaptive C genes if needed
     if to == 'adaptive' or to == 'adaptivev2':
-        logger.info('Adaptive only captures VDJ genes. Converted C genes will become NA.')
+        logger.info(
+            'Adaptive only captures VDJ genes. Converted C genes will become NA.'
+        )
 
     # Load lookup table
     lookup_f = choose_lookup(frm, to, species)
@@ -171,9 +185,11 @@ def convert_gene(df, frm, to, species='human', frm_cols=[], quiet=False):
     bad_genes = []
 
     for col in cols_from:
-        good_genes = df[[col]].\
-            merge(lookup[[frm, to]], how='left', left_on=col, right_on=frm).\
-            drop(columns=frm)
+        good_genes = (
+            df[[col]]
+            .merge(lookup[[frm, to]], how='left', left_on=col, right_on=frm)
+            .drop(columns=frm)
+        )
         # Note genes where the merge produced an NA on the 'to' format side
         new_bad_genes = good_genes[good_genes[to].isna()][col].dropna().tolist()
         # We don't expect the entire column of genes to be empty.
@@ -181,13 +197,17 @@ def convert_gene(df, frm, to, species='human', frm_cols=[], quiet=False):
             new_genes[col] = good_genes
             bad_genes += new_bad_genes
         else:
-            logger.warning(f"The input column '{col}' doesn't contain any valid genes and was skipped.")
+            logger.warning(
+                f"The input column '{col}' doesn't contain any valid genes and was skipped."
+            )
             continue
 
     # Display genes we couldn't convert
     if bad_genes:
         sorted_list = sorted(list(set(bad_genes)))
-        logger.warning(f'These genes are not in IMGT for this species and will be replaced with NA:\n {str(sorted_list)}')
+        logger.warning(
+            f'These genes are not in IMGT for this species and will be replaced with NA:\n {str(sorted_list)}'
+        )
 
     # Swap out data in original dataframe
     out_df = df.copy()
@@ -202,18 +222,49 @@ def convert_gene(df, frm, to, species='human', frm_cols=[], quiet=False):
 
 # Command-line version of convert_gene()
 @click.command(name='convert', no_args_is_help=True)
-@click.option('-i', '--infile', help='Path to input CSV or TSV', required=True, type=click.Path(exists=True))
+@click.option(
+    '-i',
+    '--infile',
+    help='Path to input CSV or TSV',
+    required=True,
+    type=click.Path(exists=True),
+)
 @click.option('-o', '--outfile', help='Path to output CSV or TSV', required=True)
-@click.option('-f', '--frm', help='Input format of TCR data', required=True,
-              type=click.Choice(['tenx', 'adaptive', 'adaptivev2', 'imgt'], case_sensitive=False))
-@click.option('-t', '--to', help='Output format of TCR data', required=True,
-              type=click.Choice(['tenx', 'adaptive', 'adaptivev2', 'imgt'], case_sensitive=False))
-@click.option('-s', '--species', default='human', help='Species name.', show_default=True)
-@click.option('-c', '--frm_cols', default=[], help='List of custom V/D/J/C gene column names.', show_default=True,
-              multiple=True)
-@click.option('-q', '--quiet', is_flag=True, default=False, help='Whether to suppress warning messages.', show_default=True)
+@click.option(
+    '-f',
+    '--frm',
+    help='Input format of TCR data',
+    required=True,
+    type=click.Choice(['tenx', 'adaptive', 'adaptivev2', 'imgt'], case_sensitive=False),
+)
+@click.option(
+    '-t',
+    '--to',
+    help='Output format of TCR data',
+    required=True,
+    type=click.Choice(['tenx', 'adaptive', 'adaptivev2', 'imgt'], case_sensitive=False),
+)
+@click.option(
+    '-s', '--species', default='human', help='Species name.', show_default=True
+)
+@click.option(
+    '-c',
+    '--frm_cols',
+    default=[],
+    help='List of custom V/D/J/C gene column names.',
+    show_default=True,
+    multiple=True,
+)
+@click.option(
+    '-q',
+    '--quiet',
+    is_flag=True,
+    default=False,
+    help='Whether to suppress warning messages.',
+    show_default=True,
+)
 def convert_gene_cli(infile, outfile, frm, to, species, frm_cols, quiet):
-    '''Convert T-cell receptor V/D/J/C gene names.
+    """Convert T-cell receptor V/D/J/C gene names.
 
     :Example:
 
@@ -229,7 +280,7 @@ def convert_gene_cli(infile, outfile, frm, to, species, frm_cols, quiet):
            -c myVgene \\
            -c myDgene \\
            -c myJgene
-    '''
+    """
 
     # Check that input and output paths are CSV/TSV
     if not infile.endswith(('csv', 'tsv')):

--- a/tcrconvert/utils.py
+++ b/tcrconvert/utils.py
@@ -1,7 +1,8 @@
 from importlib.resources import files
 
+
 def get_example_path(file_name):
-    '''Get full path to given example file or directory.
+    """Get full path to given example file or directory.
 
     :param file_name: Name of the example file or directory
     :type file_name: str
@@ -13,7 +14,7 @@ def get_example_path(file_name):
     >>> import tcrconvert
     >>> tcrconvert.get_example_path('tenx.csv')
     '.../tcrconvert/examples/tenx.csv'
-    '''
+    """
 
     out = files('tcrconvert') / 'examples' / file_name
     return str(out)

--- a/tests/test_build_lookup.py
+++ b/tests/test_build_lookup.py
@@ -4,21 +4,30 @@ import tempfile
 from unittest.mock import patch
 from tcrconvert import build_lookup, utils
 
+
 def test_parse_imgt_fasta():
     fasta = utils.get_example_path('fasta_dir/test_trav.fa')
-    assert build_lookup.parse_imgt_fasta(fasta) == ['TRAV1*01', 
-                                                    'TRAV14/DV4*01', 
-                                                    'TRAV38-2/DV8*01']
+    assert build_lookup.parse_imgt_fasta(fasta) == [
+        'TRAV1*01',
+        'TRAV14/DV4*01',
+        'TRAV38-2/DV8*01',
+    ]
 
 
 def test_extract_imgt_genes():
     fastadir = utils.get_example_path('fasta_dir') + '/'
     df = build_lookup.extract_imgt_genes(fastadir)
-    outdf = pd.DataFrame({'imgt': ['TRAV1*01',
-                                    'TRAV14/DV4*01',
-                                    'TRAV38-2/DV8*01',
-                                    'TRBV29/OR9-2*01',
-                                    'TRBVA/OR9-2*01']})
+    outdf = pd.DataFrame(
+        {
+            'imgt': [
+                'TRAV1*01',
+                'TRAV14/DV4*01',
+                'TRAV38-2/DV8*01',
+                'TRBV29/OR9-2*01',
+                'TRBVA/OR9-2*01',
+            ]
+        }
+    )
     pd.testing.assert_frame_equal(df, outdf)
 
 
@@ -43,34 +52,40 @@ def test_build_lookup_from_fastas():
     mock_path = os.path.join(tempfile.gettempdir(), 'mock_data')
     os.makedirs(mock_path, exist_ok=True)
 
-    with patch("platformdirs.user_data_dir", return_value=str(mock_path)):
-        build_lookup.build_lookup_from_fastas(fastadir, species = 'rabbit')
+    with patch('platformdirs.user_data_dir', return_value=str(mock_path)):
+        build_lookup.build_lookup_from_fastas(fastadir, species='rabbit')
 
     with open(mock_path + '/rabbit/lookup_from_adaptive.csv') as lookupadapt:
-        assert lookupadapt.read() == 'adaptive,adaptivev2,imgt,tenx\n' \
-                                     'TCRAV01-01*01,TCRAV01-01*01,TRAV1*01,TRAV1\n' \
-                                     'TCRAV14-01*01,TCRAV14-01*01,TRAV14/DV4*01,TRAV14DV4\n' \
-                                     'TCRAV38-02*01,TCRAV38-02*01,TRAV38-2/DV8*01,TRAV38-2DV8\n' \
-                                     'TCRBV29-or09_02*01,TCRBV29-or09_02*01,TRBV29/OR9-2*01,TRBV29/OR9-2\n' \
-                                     'TCRBVA-or09_02*01,TCRBVA-or09_02*01,TRBVA/OR9-2*01,TRBVA/OR9-2\n' \
-                                     'TCRAV01-01,TCRAV01-01,TRAV1*01,TRAV1\n' \
-                                     'TCRAV14-01,TCRAV14-01,TRAV14/DV4*01,TRAV14DV4\n' \
-                                     'TCRAV38-02,TCRAV38-02,TRAV38-2/DV8*01,TRAV38-2DV8\n' \
-                                     'TCRBV29-or09_02,TCRBV29-or09_02,TRBV29/OR9-2*01,TRBV29/OR9-2\n' \
-                                     'TCRBVA-or09_02,TCRBVA-or09_02,TRBVA/OR9-2*01,TRBVA/OR9-2\n'
+        assert (
+            lookupadapt.read() == 'adaptive,adaptivev2,imgt,tenx\n'
+            'TCRAV01-01*01,TCRAV01-01*01,TRAV1*01,TRAV1\n'
+            'TCRAV14-01*01,TCRAV14-01*01,TRAV14/DV4*01,TRAV14DV4\n'
+            'TCRAV38-02*01,TCRAV38-02*01,TRAV38-2/DV8*01,TRAV38-2DV8\n'
+            'TCRBV29-or09_02*01,TCRBV29-or09_02*01,TRBV29/OR9-2*01,TRBV29/OR9-2\n'
+            'TCRBVA-or09_02*01,TCRBVA-or09_02*01,TRBVA/OR9-2*01,TRBVA/OR9-2\n'
+            'TCRAV01-01,TCRAV01-01,TRAV1*01,TRAV1\n'
+            'TCRAV14-01,TCRAV14-01,TRAV14/DV4*01,TRAV14DV4\n'
+            'TCRAV38-02,TCRAV38-02,TRAV38-2/DV8*01,TRAV38-2DV8\n'
+            'TCRBV29-or09_02,TCRBV29-or09_02,TRBV29/OR9-2*01,TRBV29/OR9-2\n'
+            'TCRBVA-or09_02,TCRBVA-or09_02,TRBVA/OR9-2*01,TRBVA/OR9-2\n'
+        )
 
     with open(mock_path + '/rabbit/lookup_from_tenx.csv') as lookup10x:
-        assert lookup10x.read() == 'tenx,imgt,adaptive,adaptivev2\n' \
-                                   'TRAV1,TRAV1*01,TCRAV01-01*01,TCRAV01-01*01\n' \
-                                   'TRAV14DV4,TRAV14/DV4*01,TCRAV14-01*01,TCRAV14-01*01\n' \
-                                   'TRAV38-2DV8,TRAV38-2/DV8*01,TCRAV38-02*01,TCRAV38-02*01\n' \
-                                   'TRBV29/OR9-2,TRBV29/OR9-2*01,TCRBV29-or09_02*01,TCRBV29-or09_02*01\n' \
-                                   'TRBVA/OR9-2,TRBVA/OR9-2*01,TCRBVA-or09_02*01,TCRBVA-or09_02*01\n'
+        assert (
+            lookup10x.read() == 'tenx,imgt,adaptive,adaptivev2\n'
+            'TRAV1,TRAV1*01,TCRAV01-01*01,TCRAV01-01*01\n'
+            'TRAV14DV4,TRAV14/DV4*01,TCRAV14-01*01,TCRAV14-01*01\n'
+            'TRAV38-2DV8,TRAV38-2/DV8*01,TCRAV38-02*01,TCRAV38-02*01\n'
+            'TRBV29/OR9-2,TRBV29/OR9-2*01,TCRBV29-or09_02*01,TCRBV29-or09_02*01\n'
+            'TRBVA/OR9-2,TRBVA/OR9-2*01,TCRBVA-or09_02*01,TCRBVA-or09_02*01\n'
+        )
 
     with open(mock_path + '/rabbit/lookup.csv') as lookup:
-        assert lookup.read() == 'imgt,tenx,adaptive,adaptivev2\n' \
-                                'TRAV1*01,TRAV1,TCRAV01-01*01,TCRAV01-01*01\n' \
-                                'TRAV14/DV4*01,TRAV14DV4,TCRAV14-01*01,TCRAV14-01*01\n' \
-                                'TRAV38-2/DV8*01,TRAV38-2DV8,TCRAV38-02*01,TCRAV38-02*01\n' \
-                                'TRBV29/OR9-2*01,TRBV29/OR9-2,TCRBV29-or09_02*01,TCRBV29-or09_02*01\n' \
-                                'TRBVA/OR9-2*01,TRBVA/OR9-2,TCRBVA-or09_02*01,TCRBVA-or09_02*01\n'
+        assert (
+            lookup.read() == 'imgt,tenx,adaptive,adaptivev2\n'
+            'TRAV1*01,TRAV1,TCRAV01-01*01,TCRAV01-01*01\n'
+            'TRAV14/DV4*01,TRAV14DV4,TCRAV14-01*01,TCRAV14-01*01\n'
+            'TRAV38-2/DV8*01,TRAV38-2DV8,TCRAV38-02*01,TCRAV38-02*01\n'
+            'TRBV29/OR9-2*01,TRBV29/OR9-2,TCRBV29-or09_02*01,TCRBV29-or09_02*01\n'
+            'TRBVA/OR9-2*01,TRBVA/OR9-2,TCRBVA-or09_02*01,TCRBVA-or09_02*01\n'
+        )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,75 +15,112 @@ def test_build_lookup_from_fastas_cli():
     mock_path = os.path.join(tempfile.gettempdir(), 'mock_data')
     os.makedirs(mock_path, exist_ok=True)
 
-    with patch("platformdirs.user_data_dir", return_value=str(mock_path)):
-        result = CliRunner().invoke(cli.entry_point, [
-            'build',
-            '-i', fastadir,
-            '-s', 'rabbit',
-        ], catch_exceptions=False)
+    with patch('platformdirs.user_data_dir', return_value=str(mock_path)):
+        result = CliRunner().invoke(
+            cli.entry_point,
+            [
+                'build',
+                '-i',
+                fastadir,
+                '-s',
+                'rabbit',
+            ],
+            catch_exceptions=False,
+        )
 
     assert result.exit_code == 0
 
     with open(mock_path + '/rabbit/lookup_from_adaptive.csv') as lookupadapt:
-        assert lookupadapt.read() == 'adaptive,adaptivev2,imgt,tenx\n' \
-                                     'TCRAV01-01*01,TCRAV01-01*01,TRAV1*01,TRAV1\n' \
-                                     'TCRAV14-01*01,TCRAV14-01*01,TRAV14/DV4*01,TRAV14DV4\n' \
-                                     'TCRAV38-02*01,TCRAV38-02*01,TRAV38-2/DV8*01,TRAV38-2DV8\n' \
-                                     'TCRBV29-or09_02*01,TCRBV29-or09_02*01,TRBV29/OR9-2*01,TRBV29/OR9-2\n' \
-                                     'TCRBVA-or09_02*01,TCRBVA-or09_02*01,TRBVA/OR9-2*01,TRBVA/OR9-2\n' \
-                                     'TCRAV01-01,TCRAV01-01,TRAV1*01,TRAV1\n' \
-                                     'TCRAV14-01,TCRAV14-01,TRAV14/DV4*01,TRAV14DV4\n' \
-                                     'TCRAV38-02,TCRAV38-02,TRAV38-2/DV8*01,TRAV38-2DV8\n' \
-                                     'TCRBV29-or09_02,TCRBV29-or09_02,TRBV29/OR9-2*01,TRBV29/OR9-2\n' \
-                                     'TCRBVA-or09_02,TCRBVA-or09_02,TRBVA/OR9-2*01,TRBVA/OR9-2\n'
+        assert (
+            lookupadapt.read() == 'adaptive,adaptivev2,imgt,tenx\n'
+            'TCRAV01-01*01,TCRAV01-01*01,TRAV1*01,TRAV1\n'
+            'TCRAV14-01*01,TCRAV14-01*01,TRAV14/DV4*01,TRAV14DV4\n'
+            'TCRAV38-02*01,TCRAV38-02*01,TRAV38-2/DV8*01,TRAV38-2DV8\n'
+            'TCRBV29-or09_02*01,TCRBV29-or09_02*01,TRBV29/OR9-2*01,TRBV29/OR9-2\n'
+            'TCRBVA-or09_02*01,TCRBVA-or09_02*01,TRBVA/OR9-2*01,TRBVA/OR9-2\n'
+            'TCRAV01-01,TCRAV01-01,TRAV1*01,TRAV1\n'
+            'TCRAV14-01,TCRAV14-01,TRAV14/DV4*01,TRAV14DV4\n'
+            'TCRAV38-02,TCRAV38-02,TRAV38-2/DV8*01,TRAV38-2DV8\n'
+            'TCRBV29-or09_02,TCRBV29-or09_02,TRBV29/OR9-2*01,TRBV29/OR9-2\n'
+            'TCRBVA-or09_02,TCRBVA-or09_02,TRBVA/OR9-2*01,TRBVA/OR9-2\n'
+        )
 
     with open(mock_path + '/rabbit/lookup_from_tenx.csv') as lookup10x:
-        assert lookup10x.read() == 'tenx,imgt,adaptive,adaptivev2\n' \
-                                   'TRAV1,TRAV1*01,TCRAV01-01*01,TCRAV01-01*01\n' \
-                                   'TRAV14DV4,TRAV14/DV4*01,TCRAV14-01*01,TCRAV14-01*01\n' \
-                                   'TRAV38-2DV8,TRAV38-2/DV8*01,TCRAV38-02*01,TCRAV38-02*01\n' \
-                                   'TRBV29/OR9-2,TRBV29/OR9-2*01,TCRBV29-or09_02*01,TCRBV29-or09_02*01\n' \
-                                   'TRBVA/OR9-2,TRBVA/OR9-2*01,TCRBVA-or09_02*01,TCRBVA-or09_02*01\n'
+        assert (
+            lookup10x.read() == 'tenx,imgt,adaptive,adaptivev2\n'
+            'TRAV1,TRAV1*01,TCRAV01-01*01,TCRAV01-01*01\n'
+            'TRAV14DV4,TRAV14/DV4*01,TCRAV14-01*01,TCRAV14-01*01\n'
+            'TRAV38-2DV8,TRAV38-2/DV8*01,TCRAV38-02*01,TCRAV38-02*01\n'
+            'TRBV29/OR9-2,TRBV29/OR9-2*01,TCRBV29-or09_02*01,TCRBV29-or09_02*01\n'
+            'TRBVA/OR9-2,TRBVA/OR9-2*01,TCRBVA-or09_02*01,TCRBVA-or09_02*01\n'
+        )
 
     with open(mock_path + '/rabbit/lookup.csv') as lookup:
-        assert lookup.read() == 'imgt,tenx,adaptive,adaptivev2\n' \
-                                'TRAV1*01,TRAV1,TCRAV01-01*01,TCRAV01-01*01\n' \
-                                'TRAV14/DV4*01,TRAV14DV4,TCRAV14-01*01,TCRAV14-01*01\n' \
-                                'TRAV38-2/DV8*01,TRAV38-2DV8,TCRAV38-02*01,TCRAV38-02*01\n' \
-                                'TRBV29/OR9-2*01,TRBV29/OR9-2,TCRBV29-or09_02*01,TCRBV29-or09_02*01\n' \
-                                'TRBVA/OR9-2*01,TRBVA/OR9-2,TCRBVA-or09_02*01,TCRBVA-or09_02*01\n'
+        assert (
+            lookup.read() == 'imgt,tenx,adaptive,adaptivev2\n'
+            'TRAV1*01,TRAV1,TCRAV01-01*01,TCRAV01-01*01\n'
+            'TRAV14/DV4*01,TRAV14DV4,TCRAV14-01*01,TCRAV14-01*01\n'
+            'TRAV38-2/DV8*01,TRAV38-2DV8,TCRAV38-02*01,TCRAV38-02*01\n'
+            'TRBV29/OR9-2*01,TRBV29/OR9-2,TCRBV29-or09_02*01,TCRBV29-or09_02*01\n'
+            'TRBVA/OR9-2*01,TRBVA/OR9-2,TCRBVA-or09_02*01,TCRBVA-or09_02*01\n'
+        )
 
 
 def test_convert_gene_cli(caplog):
-    result = CliRunner().invoke(cli.entry_point, [
-        'convert',
-        '--infile', in_csv,
-        '--outfile', out_tsv,
-        '--frm', 'tenx',
-        '--to', 'adaptive',
-        '--species', 'mouse',
-        '-c', 'myVgene',
-        '-c', 'myDgene',
-        '-c', 'myJgene',
-        '-c', 'myCgene'
-    ], catch_exceptions=False)
+    result = CliRunner().invoke(
+        cli.entry_point,
+        [
+            'convert',
+            '--infile',
+            in_csv,
+            '--outfile',
+            out_tsv,
+            '--frm',
+            'tenx',
+            '--to',
+            'adaptive',
+            '--species',
+            'mouse',
+            '-c',
+            'myVgene',
+            '-c',
+            'myDgene',
+            '-c',
+            'myJgene',
+            '-c',
+            'myCgene',
+        ],
+        catch_exceptions=False,
+    )
 
     assert result.exit_code == 0
 
     # Expected warning messages
-    assert "Adaptive only captures VDJ genes. Converted C genes will become NA." in caplog.text
-    assert "Converting from 10X which lacks allele info. Choosing *01 as allele for all genes." in caplog.text
-    assert "These genes are not in IMGT for this species and will be replaced with NA:" in caplog.text
+    assert (
+        'Adaptive only captures VDJ genes. Converted C genes will become NA.'
+        in caplog.text
+    )
+    assert (
+        'Converting from 10X which lacks allele info. Choosing *01 as allele for all genes.'
+        in caplog.text
+    )
+    assert (
+        'These genes are not in IMGT for this species and will be replaced with NA:'
+        in caplog.text
+    )
     assert " ['TRAV1-2', 'TRBV6-1', 'TRBV6-4']" in caplog.text
 
     # Expected output file contents
     with open(out_tsv) as output:
-        assert output.read() == 'myVgene	myDgene	myJgene	myCgene	myCDR3	antigen\n' \
-                                '	TCRBD01-01*01	TCRAJ12-01*01		CAVMDSSYKLIF	Flu\n' \
-                                '	TCRBD02-01*01	TCRBJ02-01*01		CASSGLAGGYNEQFF	Flu\n' \
-                                '	TCRBD02-01*01	TCRBJ02-03*01		CASSGVAGGTDTQYF	CMV\n' \
-                                '	TCRBD01-01*01	TCRAJ33-01*01		CAVKDSNYQLIW	CMV\n' \
-                                'TCRBV02-01*01	TCRBD01-01*01	TCRBJ01-02*01		CASNQGLNYGYTF	CMV\n'
+        assert (
+            output.read()
+            == 'myVgene	myDgene	myJgene	myCgene	myCDR3	antigen\n'
+            '	TCRBD01-01*01	TCRAJ12-01*01		CAVMDSSYKLIF	Flu\n'
+            '	TCRBD02-01*01	TCRBJ02-01*01		CASSGLAGGYNEQFF	Flu\n'
+            '	TCRBD02-01*01	TCRBJ02-03*01		CASSGVAGGTDTQYF	CMV\n'
+            '	TCRBD01-01*01	TCRAJ33-01*01		CAVKDSNYQLIW	CMV\n'
+            'TCRBV02-01*01	TCRBD01-01*01	TCRBJ01-02*01		CASNQGLNYGYTF	CMV\n'
+        )
 
 
 def test_convert_gene_cli_errors():
@@ -91,35 +128,61 @@ def test_convert_gene_cli_errors():
     badoutfile = os.path.dirname(__file__) + '/data/badoutput.txt'
 
     # Input not CSV/TSV
-    result_in = CliRunner().invoke(cli.entry_point, [
+    result_in = CliRunner().invoke(
+        cli.entry_point,
+        [
             'convert',
-            '--infile', badinfile,
-            '--outfile', out_tsv,
-            '--frm', 'tenx',
-            '--to', 'adaptive',
-            '--species', 'mouse',
-            '-c', 'myVgene',
-            '-c', 'myDgene',
-            '-c', 'myJgene',
-            '-c', 'myCgene'
-        ], catch_exceptions=False)
-    
+            '--infile',
+            badinfile,
+            '--outfile',
+            out_tsv,
+            '--frm',
+            'tenx',
+            '--to',
+            'adaptive',
+            '--species',
+            'mouse',
+            '-c',
+            'myVgene',
+            '-c',
+            'myDgene',
+            '-c',
+            'myJgene',
+            '-c',
+            'myCgene',
+        ],
+        catch_exceptions=False,
+    )
+
     assert result_in.exit_code != 0
     assert '"infile" must be a .csv or .tsv file' in result_in.output
 
     # Output not CSV/TSV
-    result_out = CliRunner().invoke(cli.entry_point, [
+    result_out = CliRunner().invoke(
+        cli.entry_point,
+        [
             'convert',
-            '--infile', in_csv,
-            '--outfile', badoutfile,
-            '--frm', 'tenx',
-            '--to', 'adaptive',
-            '--species', 'mouse',
-            '-c', 'myVgene',
-            '-c', 'myDgene',
-            '-c', 'myJgene',
-            '-c', 'myCgene'
-        ], catch_exceptions=False)
+            '--infile',
+            in_csv,
+            '--outfile',
+            badoutfile,
+            '--frm',
+            'tenx',
+            '--to',
+            'adaptive',
+            '--species',
+            'mouse',
+            '-c',
+            'myVgene',
+            '-c',
+            'myDgene',
+            '-c',
+            'myJgene',
+            '-c',
+            'myCgene',
+        ],
+        catch_exceptions=False,
+    )
 
     assert result_out.exit_code != 0
     assert '"outfile" must be a .csv or .tsv file' in result_out.output

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -4,125 +4,206 @@ import os
 from importlib.resources import files
 from tcrconvert import convert
 
-imgt_df = pd.DataFrame({'v_gene': ['TRAV12-1*01', 'TRBV15*01'],
-                        'd_gene': [pd.NA, 'TRBD1*01'],
-                        'j_gene': ['TRAJ16*01', 'TRBJ2-5*01'],
-                        'c_gene': ['TRAC*01', 'TRBC2*01'],
-                        'cdr3': ['CAVLIF', 'CASSGF']})
+imgt_df = pd.DataFrame(
+    {
+        'v_gene': ['TRAV12-1*01', 'TRBV15*01'],
+        'd_gene': [pd.NA, 'TRBD1*01'],
+        'j_gene': ['TRAJ16*01', 'TRBJ2-5*01'],
+        'c_gene': ['TRAC*01', 'TRBC2*01'],
+        'cdr3': ['CAVLIF', 'CASSGF'],
+    }
+)
 
-tenx_df = pd.DataFrame({'v_gene': ['TRAV12-1', 'TRBV15'],
-                        'd_gene': [pd.NA, 'TRBD1'],
-                        'j_gene': ['TRAJ16', 'TRBJ2-5'],
-                        'c_gene': ['TRAC', 'TRBC2'],
-                        'cdr3': ['CAVLIF', 'CASSGF']})
+tenx_df = pd.DataFrame(
+    {
+        'v_gene': ['TRAV12-1', 'TRBV15'],
+        'd_gene': [pd.NA, 'TRBD1'],
+        'j_gene': ['TRAJ16', 'TRBJ2-5'],
+        'c_gene': ['TRAC', 'TRBC2'],
+        'cdr3': ['CAVLIF', 'CASSGF'],
+    }
+)
 
-adapt_df = pd.DataFrame({'v_resolved': ['TCRAV12-01*01', 'TCRBV15-01*01'],
-                         'd_resolved': [pd.NA, 'TCRBD01-01*01'],
-                         'j_resolved': ['TCRAJ16-01*01', 'TCRBJ02-05*01'],
-                         'cdr3_amino_acid': ['CAVLIF', 'CASSGF']})
+adapt_df = pd.DataFrame(
+    {
+        'v_resolved': ['TCRAV12-01*01', 'TCRBV15-01*01'],
+        'd_resolved': [pd.NA, 'TCRBD01-01*01'],
+        'j_resolved': ['TCRAJ16-01*01', 'TCRBJ02-05*01'],
+        'cdr3_amino_acid': ['CAVLIF', 'CASSGF'],
+    }
+)
 
-adapt_v2_df = adapt_df.rename(columns={'v_resolved': 'vMaxResolved', 
-                                       'd_resolved': 'dMaxResolved',
-                                       'j_resolved': 'jMaxResolved',
-                                       'cdr3_amino_acid': 'aminoAcid'})
+adapt_v2_df = adapt_df.rename(
+    columns={
+        'v_resolved': 'vMaxResolved',
+        'd_resolved': 'dMaxResolved',
+        'j_resolved': 'jMaxResolved',
+        'cdr3_amino_acid': 'aminoAcid',
+    }
+)
 
-custom_df = imgt_df.rename(columns={'v_gene': 'myV',
-                                    'd_gene': 'myD',
-                                    'j_gene': 'myJ',
-                                    'c_gene': 'myC',
-                                    'cdr3': 'myCDR3'})
+custom_df = imgt_df.rename(
+    columns={
+        'v_gene': 'myV',
+        'd_gene': 'myD',
+        'j_gene': 'myJ',
+        'c_gene': 'myC',
+        'cdr3': 'myCDR3',
+    }
+)
 
-custom_vj_tenx_df = pd.DataFrame({'myV': ['TRAV12-1', 'TRBV15'],
-                                  'myD': [pd.NA, 'TRBD1*01'],
-                                  'myJ': ['TRAJ16', 'TRBJ2-5'],
-                                  'myC': ['TRAC*01', 'TRBC2*01'],
-                                  'myCDR3': ['CAVLIF', 'CASSGF']})
+custom_vj_tenx_df = pd.DataFrame(
+    {
+        'myV': ['TRAV12-1', 'TRBV15'],
+        'myD': [pd.NA, 'TRBD1*01'],
+        'myJ': ['TRAJ16', 'TRBJ2-5'],
+        'myC': ['TRAC*01', 'TRBC2*01'],
+        'myCDR3': ['CAVLIF', 'CASSGF'],
+    }
+)
 
-tenx_to_adapt_df = adapt_df.rename(columns={'v_resolved': 'v_gene', 
-                                            'd_resolved': 'd_gene',
-                                            'j_resolved': 'j_gene',
-                                            'cdr3_amino_acid': 'cdr3'})
+tenx_to_adapt_df = adapt_df.rename(
+    columns={
+        'v_resolved': 'v_gene',
+        'd_resolved': 'd_gene',
+        'j_resolved': 'j_gene',
+        'cdr3_amino_acid': 'cdr3',
+    }
+)
 tenx_to_adapt_df.insert(3, 'c_gene', [pd.NA, pd.NA])
 
-adapt_to_tenx_df = tenx_df.rename(columns={'v_gene': 'v_resolved',
-                                           'd_gene': 'd_resolved',
-                                           'j_gene': 'j_resolved',
-                                           'cdr3': 'cdr3_amino_acid'}).\
-                            drop(columns='c_gene')
+adapt_to_tenx_df = tenx_df.rename(
+    columns={
+        'v_gene': 'v_resolved',
+        'd_gene': 'd_resolved',
+        'j_gene': 'j_resolved',
+        'cdr3': 'cdr3_amino_acid',
+    }
+).drop(columns='c_gene')
 
-adapt_to_imgt_df = imgt_df.rename(columns={'v_gene': 'v_resolved',
-                                           'd_gene': 'd_resolved',
-                                           'j_gene': 'j_resolved',
-                                           'cdr3': 'cdr3_amino_acid'}).\
-                            drop(columns='c_gene')
+adapt_to_imgt_df = imgt_df.rename(
+    columns={
+        'v_gene': 'v_resolved',
+        'd_gene': 'd_resolved',
+        'j_gene': 'j_resolved',
+        'cdr3': 'cdr3_amino_acid',
+    }
+).drop(columns='c_gene')
 
-adaptv2_to_tenx_df = tenx_df.rename(columns={'v_gene': 'vMaxResolved',
-                                             'd_gene': 'dMaxResolved',
-                                             'j_gene': 'jMaxResolved',
-                                             'cdr3': 'aminoAcid'}).\
-                            drop(columns='c_gene')
+adaptv2_to_tenx_df = tenx_df.rename(
+    columns={
+        'v_gene': 'vMaxResolved',
+        'd_gene': 'dMaxResolved',
+        'j_gene': 'jMaxResolved',
+        'cdr3': 'aminoAcid',
+    }
+).drop(columns='c_gene')
 
-adaptv2_to_imgt_df = imgt_df.rename(columns={'v_gene': 'vMaxResolved',
-                                             'd_gene': 'dMaxResolved',
-                                             'j_gene': 'jMaxResolved',
-                                             'cdr3': 'aminoAcid'}).\
-                            drop(columns='c_gene')
+adaptv2_to_imgt_df = imgt_df.rename(
+    columns={
+        'v_gene': 'vMaxResolved',
+        'd_gene': 'dMaxResolved',
+        'j_gene': 'jMaxResolved',
+        'cdr3': 'aminoAcid',
+    }
+).drop(columns='c_gene')
 
-custom_to_tenx_df = tenx_df.rename(columns={'v_gene': 'myV',
-                                            'd_gene': 'myD',
-                                            'j_gene': 'myJ',
-                                            'c_gene': 'myC',
-                                            'cdr3': 'myCDR3'})
+custom_to_tenx_df = tenx_df.rename(
+    columns={
+        'v_gene': 'myV',
+        'd_gene': 'myD',
+        'j_gene': 'myJ',
+        'c_gene': 'myC',
+        'cdr3': 'myCDR3',
+    }
+)
 
-adapt_no_allele_df = pd.DataFrame({'v_resolved': ['TCRAV12-01', 'TCRBV15-01*01'],
-                                    'd_resolved': [pd.NA, 'TCRBD01-01'],
-                                    'j_resolved': ['TCRAJ16-01*01', 'TCRBJ02-05'],
-                                    'cdr3_amino_acid': ['CAVLIF', 'CASSGF']})
+adapt_no_allele_df = pd.DataFrame(
+    {
+        'v_resolved': ['TCRAV12-01', 'TCRBV15-01*01'],
+        'd_resolved': [pd.NA, 'TCRBD01-01'],
+        'j_resolved': ['TCRAJ16-01*01', 'TCRBJ02-05'],
+        'cdr3_amino_acid': ['CAVLIF', 'CASSGF'],
+    }
+)
 
-@pytest.mark.parametrize('df, frm, to, species, frm_cols, out', [
-    # 10X <-> Adaptive
-    (tenx_df, 'tenx', 'adaptive', 'human', None, tenx_to_adapt_df),
-    (tenx_df, 'tenx', 'adaptivev2', 'human', None, tenx_to_adapt_df),
-    (adapt_df, 'adaptive', 'tenx', 'human', None, adapt_to_tenx_df),
-    (adapt_v2_df, 'adaptivev2', 'tenx', 'human', None, adaptv2_to_tenx_df),
-    # 10X <-> IMGT
-    (tenx_df, 'tenx', 'imgt', 'human', None, imgt_df),
-    (imgt_df, 'imgt', 'tenx', 'human', None, tenx_df),
-    # IMGT <-> Adaptive
-    (imgt_df, 'imgt', 'adaptive', 'human', None, tenx_to_adapt_df),
-    (imgt_df, 'imgt', 'adaptivev2', 'human', None, tenx_to_adapt_df),
-    (adapt_df, 'adaptive', 'imgt', 'human', None, adapt_to_imgt_df),
-    (adapt_v2_df, 'adaptivev2', 'imgt', 'human', None, adaptv2_to_imgt_df),
-    # Custom column names
-    (custom_df, 'imgt', 'tenx', 'human', ['myV', 'myD', 'myJ', 'myC'], custom_to_tenx_df),
-    # MOUSE
-    (tenx_df, 'tenx', 'adaptive', 'mouse', None, tenx_to_adapt_df),
-    (tenx_df, 'tenx', 'adaptivev2', 'mouse', None, tenx_to_adapt_df),
-    (adapt_df, 'adaptive', 'tenx', 'mouse', None, adapt_to_tenx_df),
-    (adapt_v2_df, 'adaptivev2', 'tenx', 'mouse', None, adaptv2_to_tenx_df),
-    (tenx_df, 'tenx', 'imgt', 'mouse', None, imgt_df),
-    (imgt_df, 'imgt', 'tenx', 'mouse', None, tenx_df),
-    (imgt_df, 'imgt', 'adaptive', 'mouse', None, tenx_to_adapt_df),
-    (imgt_df, 'imgt', 'adaptivev2', 'mouse', None, tenx_to_adapt_df),
-    (adapt_df, 'adaptive', 'imgt', 'mouse', None, adapt_to_imgt_df),
-    (adapt_v2_df, 'adaptivev2', 'imgt', 'mouse', None, adaptv2_to_imgt_df),
-    (custom_df, 'imgt', 'tenx', 'mouse', ['myV', 'myD', 'myJ', 'myC'], custom_to_tenx_df),
-    # RHESUS MACAQUE
-    (tenx_df, 'tenx', 'adaptive', 'rhesus', None, tenx_to_adapt_df),
-    (tenx_df, 'tenx', 'adaptivev2', 'rhesus', None, tenx_to_adapt_df),
-    (adapt_df, 'adaptive', 'tenx', 'rhesus', None, adapt_to_tenx_df),
-    (adapt_v2_df, 'adaptivev2', 'tenx', 'rhesus', None, adaptv2_to_tenx_df),
-    (tenx_df, 'tenx', 'imgt', 'rhesus', None, imgt_df),
-    (imgt_df, 'imgt', 'tenx', 'rhesus', None, tenx_df),
-    (imgt_df, 'imgt', 'adaptive', 'rhesus', None, tenx_to_adapt_df),
-    (imgt_df, 'imgt', 'adaptivev2', 'rhesus', None, tenx_to_adapt_df),
-    (adapt_df, 'adaptive', 'imgt', 'rhesus', None, adapt_to_imgt_df),
-    (adapt_v2_df, 'adaptivev2', 'imgt', 'rhesus', None, adaptv2_to_imgt_df),
-    (custom_df, 'imgt', 'tenx', 'rhesus', ['myV', 'myD', 'myJ', 'myC'], custom_to_tenx_df),
-    # Some Adaptive genes without allele
-    (adapt_no_allele_df, 'adaptive', 'imgt', 'human', None, adapt_to_imgt_df),
-    # Confirm won't convert non-VDJC gene column to NAs
-    (custom_df, 'imgt', 'tenx', 'human', ['myV', 'myJ', 'myCDR3'], custom_vj_tenx_df)])
+
+@pytest.mark.parametrize(
+    'df, frm, to, species, frm_cols, out',
+    [
+        # 10X <-> Adaptive
+        (tenx_df, 'tenx', 'adaptive', 'human', None, tenx_to_adapt_df),
+        (tenx_df, 'tenx', 'adaptivev2', 'human', None, tenx_to_adapt_df),
+        (adapt_df, 'adaptive', 'tenx', 'human', None, adapt_to_tenx_df),
+        (adapt_v2_df, 'adaptivev2', 'tenx', 'human', None, adaptv2_to_tenx_df),
+        # 10X <-> IMGT
+        (tenx_df, 'tenx', 'imgt', 'human', None, imgt_df),
+        (imgt_df, 'imgt', 'tenx', 'human', None, tenx_df),
+        # IMGT <-> Adaptive
+        (imgt_df, 'imgt', 'adaptive', 'human', None, tenx_to_adapt_df),
+        (imgt_df, 'imgt', 'adaptivev2', 'human', None, tenx_to_adapt_df),
+        (adapt_df, 'adaptive', 'imgt', 'human', None, adapt_to_imgt_df),
+        (adapt_v2_df, 'adaptivev2', 'imgt', 'human', None, adaptv2_to_imgt_df),
+        # Custom column names
+        (
+            custom_df,
+            'imgt',
+            'tenx',
+            'human',
+            ['myV', 'myD', 'myJ', 'myC'],
+            custom_to_tenx_df,
+        ),
+        # MOUSE
+        (tenx_df, 'tenx', 'adaptive', 'mouse', None, tenx_to_adapt_df),
+        (tenx_df, 'tenx', 'adaptivev2', 'mouse', None, tenx_to_adapt_df),
+        (adapt_df, 'adaptive', 'tenx', 'mouse', None, adapt_to_tenx_df),
+        (adapt_v2_df, 'adaptivev2', 'tenx', 'mouse', None, adaptv2_to_tenx_df),
+        (tenx_df, 'tenx', 'imgt', 'mouse', None, imgt_df),
+        (imgt_df, 'imgt', 'tenx', 'mouse', None, tenx_df),
+        (imgt_df, 'imgt', 'adaptive', 'mouse', None, tenx_to_adapt_df),
+        (imgt_df, 'imgt', 'adaptivev2', 'mouse', None, tenx_to_adapt_df),
+        (adapt_df, 'adaptive', 'imgt', 'mouse', None, adapt_to_imgt_df),
+        (adapt_v2_df, 'adaptivev2', 'imgt', 'mouse', None, adaptv2_to_imgt_df),
+        (
+            custom_df,
+            'imgt',
+            'tenx',
+            'mouse',
+            ['myV', 'myD', 'myJ', 'myC'],
+            custom_to_tenx_df,
+        ),
+        # RHESUS MACAQUE
+        (tenx_df, 'tenx', 'adaptive', 'rhesus', None, tenx_to_adapt_df),
+        (tenx_df, 'tenx', 'adaptivev2', 'rhesus', None, tenx_to_adapt_df),
+        (adapt_df, 'adaptive', 'tenx', 'rhesus', None, adapt_to_tenx_df),
+        (adapt_v2_df, 'adaptivev2', 'tenx', 'rhesus', None, adaptv2_to_tenx_df),
+        (tenx_df, 'tenx', 'imgt', 'rhesus', None, imgt_df),
+        (imgt_df, 'imgt', 'tenx', 'rhesus', None, tenx_df),
+        (imgt_df, 'imgt', 'adaptive', 'rhesus', None, tenx_to_adapt_df),
+        (imgt_df, 'imgt', 'adaptivev2', 'rhesus', None, tenx_to_adapt_df),
+        (adapt_df, 'adaptive', 'imgt', 'rhesus', None, adapt_to_imgt_df),
+        (adapt_v2_df, 'adaptivev2', 'imgt', 'rhesus', None, adaptv2_to_imgt_df),
+        (
+            custom_df,
+            'imgt',
+            'tenx',
+            'rhesus',
+            ['myV', 'myD', 'myJ', 'myC'],
+            custom_to_tenx_df,
+        ),
+        # Some Adaptive genes without allele
+        (adapt_no_allele_df, 'adaptive', 'imgt', 'human', None, adapt_to_imgt_df),
+        # Confirm won't convert non-VDJC gene column to NAs
+        (
+            custom_df,
+            'imgt',
+            'tenx',
+            'human',
+            ['myV', 'myJ', 'myCDR3'],
+            custom_vj_tenx_df,
+        ),
+    ],
+)
 def test_convert_gene(df, frm, to, species, frm_cols, out):
     result = convert.convert_gene(df, frm, to, species, frm_cols)
     # Standardize the NA values so we can check for equality
@@ -159,10 +240,12 @@ def test_choose_lookup():
 
 
 def test_which_frm_cols():
-    col_ref = {'adaptive': ['v_resolved', 'd_resolved', 'j_resolved'],
-               'adaptivev2': ['vMaxResolved', 'dMaxResolved', 'jMaxResolved'],
-               'imgt': ['v_gene', 'd_gene', 'j_gene', 'c_gene'],
-               'tenx': ['v_gene', 'd_gene', 'j_gene', 'c_gene']}
+    col_ref = {
+        'adaptive': ['v_resolved', 'd_resolved', 'j_resolved'],
+        'adaptivev2': ['vMaxResolved', 'dMaxResolved', 'jMaxResolved'],
+        'imgt': ['v_gene', 'd_gene', 'j_gene', 'c_gene'],
+        'tenx': ['v_gene', 'd_gene', 'j_gene', 'c_gene'],
+    }
 
     assert convert.which_frm_cols(adapt_df, 'adaptive') == col_ref['adaptive']
     assert convert.which_frm_cols(adapt_v2_df, 'adaptivev2') == col_ref['adaptivev2']


### PR DESCRIPTION
Enforce formatting by modifying the `ruff` GitHub Action to fail if files would be formatted by Ruff. In addition, modify `pyproject.toml` to specify that Ruff use single quotes for strings and target Python 3.12 when running.