### PR TITLE
Retain 'bad' genes if desired

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -9,7 +9,8 @@ includes gene names with each nomenclature. These lookup tables are constructed
 from IMGT reference FASTA files and account for the specific naming peculiarities
 of each platform. The built-in lookup tables are located under ``tcrconvert/data/``.
 The code used to build the lookup tables, which demonstrates the conversion logic, is
-within the `<build_lookup_from_fastas https://github.com/seshadrilab/tcrconvert/blob/361f930d598996f3fa239a715c829ad8c107c63e/tcrconvert/build_lookup.py#L196>_` function.
+within the ``build_lookup_from_fastas()`` function in the
+``tcrconvert.build_lookup`` module.
 
 
 What input columns are required?

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -4,26 +4,26 @@ FAQ
 How does TCRconvert work?
 ---------------------------
 
-TCRconvert performs a ``merge`` between the input data and a lookup table that 
-includes gene names with each nomenclature. These lookup tables are constructed 
-from IMGT reference FASTA files and account for the specific naming peculiarities 
-of each platform. The built-in lookup tables are located under ``tcrconvert/data/``. 
-The code used to build the lookup tables, which demonstrates the conversion logic, is 
+TCRconvert performs a ``merge`` between the input data and a lookup table that
+includes gene names with each nomenclature. These lookup tables are constructed
+from IMGT reference FASTA files and account for the specific naming peculiarities
+of each platform. The built-in lookup tables are located under ``tcrconvert/data/``.
+The code used to build the lookup tables, which demonstrates the conversion logic, is
 within the `<build_lookup_from_fastas https://github.com/seshadrilab/tcrconvert/blob/361f930d598996f3fa239a715c829ad8c107c63e/tcrconvert/build_lookup.py#L196>_` function.
 
 
 What input columns are required?
 ----------------------------------
 
-TCRconvert expects at least one V, D, J, and/or C gene column. You can use standard 
+TCRconvert expects at least one V, D, J, and/or C gene column. You can use standard
 10X and Adaptive column names or custom names.
 
 
 What if I have missing genes?
 -------------------------------
 
-``NA`` values in the input dataframe will remain ``NA`` in the output. Genes that 
-are not found in the lookup table (which is based on the IMGT reference), will be 
+``NA`` values in the input dataframe will remain ``NA`` in the output. Genes that
+are not found in the lookup table (which is based on the IMGT reference), will be
 converted to ``NA``. The built-in lookup tables are located under ``tcrconvert/data/``.
 
 
@@ -42,31 +42,31 @@ Since 10X does not provide allele-level information, all genes are assigned the 
 How are C genes converted to Adaptive?
 ----------------------------------------
 
-Adaptive does not capture constant ("C") gene information. If converting to the 
+Adaptive does not capture constant ("C") gene information. If converting to the
 Adaptive format, all C genes will be set to ``NA``.
 
 
 What column names should I use for my IMGT-formatted data?
 ------------------------------------------------------------
 
-IMGT does not have standard column names, so it's assumed that the 10X names 
-are used: (``v_gene``, ``d_gene``, ``j_gene``, ``c_gene``). To use other names, 
+IMGT does not have standard column names, so it's assumed that the 10X names
+are used: (``v_gene``, ``d_gene``, ``j_gene``, ``c_gene``). To use other names,
 specify them as a list with ``frm_cols`` (library) or ``--column`` (command-line).
 
 
 Can I input AIRR files?
 -------------------------
 
-Yes, just specify the AIRR column names (``v_call``, ``d_call``, ``j_call``, ``c_call``) 
-using ``frm_cols`` (library) or ``--column`` (command-line). You must still 
+Yes, just specify the AIRR column names (``v_call``, ``d_call``, ``j_call``, ``c_call``)
+using ``frm_cols`` (library) or ``--column`` (command-line). You must still
 specify the input naming convention with ``frm``.
 
 
 What if I have custom column names?
 -------------------------------------
 
-If you're using non-standard column names that do not match 10X, Adaptive, or 
-Adaptive V2 formats, specify them with ``frm_cols`` (library) or 
+If you're using non-standard column names that do not match 10X, Adaptive, or
+Adaptive V2 formats, specify them with ``frm_cols`` (library) or
 ``--column`` (command-line).
 
 
@@ -75,24 +75,33 @@ What about odd names (e.g. ``TRAV14DV4``, ``TCRAV01-02/12-02``)?
 
 Gene names containing "OR" or "DV" are accounted for in the lookup tables.
 
-Combinations of gene names, like ``TCRAV01-02/12-02``, will be converted to ``NA`` 
+Combinations of gene names, like ``TCRAV01-02/12-02``, will be converted to ``NA``
 because they are not in the IMGT reference.
+
+
+What about genes that aren't the reference?
+---------------------------------------------
+A warning message always lists all unique genes that could not be converted.
+
+Genes not in the reference are replaced with NA in the converted columns by default.
+If ``bad_genes_col=True``, the original unconverted gene names are retained in a
+'bad_genes' column that contains the comma-separated 'bad' names for each row.
 
 
 Are non-human species supported?
 ----------------------------------
 
-Mouse and rhesus macaque are supported out-of-the-box. For other species, see 
+Mouse and rhesus macaque are supported out-of-the-box. For other species, see
 pages for building custom lookup tables for library or command-line usage.
 
-The rhesus and mouse lookup tables were built from IMGT reference FASTAs and 
+The rhesus and mouse lookup tables were built from IMGT reference FASTAs and
 gene tables. Mouse genes cover both "Mouse" and "Mouse C57BL/6J" as listed in IMGT.
 
 
 What if my Adaptive data lacks ``x_resolved`` / ``xMaxResolved`` columns?
 ---------------------------------------------------------------------------
 
-Create them by combining ``x_gene``/``xGeneName`` and 
+Create them by combining ``x_gene``/``xGeneName`` and
 ``x_allele``/``xGeneAllele`` with ``*`` as a separator. Example code:
 
 .. code-block:: python

--- a/tcrconvert/convert.py
+++ b/tcrconvert/convert.py
@@ -311,7 +311,14 @@ def convert_gene(df, frm, to, species='human', frm_cols=[], verbose=True,
     help='Show INFO-level messages',
     show_default=True,
 )
-def convert_gene_cli(input, output, frm, to, species, column, verbose):
+@click.option(
+    '-b',
+    '--bad_genes_col',
+    default=False,
+    help='Append column of unconvertable genes',
+    show_default=True,
+)
+def convert_gene_cli(input, output, frm, to, species, column, verbose, bad_genes_col):
     """Convert T-cell receptor V/D/J/C gene names.
 
     :Example:
@@ -350,7 +357,7 @@ def convert_gene_cli(input, output, frm, to, species, column, verbose):
     # Cast frm_cols as list because will be read in from command line as tuple
     if verbose:
         click.echo(f'Converting gene nomenclature from "{frm}" to "{to}"')
-    out_df = convert_gene(df, frm, to, species, list(column), verbose)
+    out_df = convert_gene(df, frm, to, species, list(column), verbose, bad_genes_col)
 
     # Save output
     if verbose:

--- a/tcrconvert/convert.py
+++ b/tcrconvert/convert.py
@@ -140,9 +140,10 @@ def convert_gene(df, frm, to, species='human', frm_cols=[], verbose=True,
 
     Behavioral Notes:
 
-    - If a gene name cannot be mapped, it is replaced with ``NaN``, and a warning is issued.
+    - If a gene name cannot be mapped, it is replaced with ``NA``, and a warning is issued.
+    - If ``bad_genes_col=True``, appends a 'bad_genes' column containing comma-separated gene names that could not be converted for each row.
     - If ``frm`` is ``'imgt'`` and ``frm_cols`` is not provided, 10X column names are assumed.
-    - Constant (C) genes are set to ``NaN`` when converting to Adaptive formats, as Adaptive does not capture constant regions.
+    - Constant (C) genes are set to ``NA`` when converting to Adaptive formats, as Adaptive does not capture constant regions.
     - The input does not need to include all gene types; partial inputs (e.g., only V genes) are supported.
     - If no values in a custom column can be mapped (e.g., a CDR3 column) it is skipped and a warning is raised.
 
@@ -167,6 +168,7 @@ def convert_gene(df, frm, to, species='human', frm_cols=[], verbose=True,
     :type frm_cols: list of str, optional
     :param verbose: Whether to show all messages. Defaults to ``True``.
     :type verbose: bool, optional
+    :param bad_genes_col: Whether to add a column of the unconvertable genes. Defaults to ``False``.
     :return: Converted TCR data
     :rtype: DataFrame
 

--- a/tcrconvert/convert.py
+++ b/tcrconvert/convert.py
@@ -128,7 +128,8 @@ def which_frm_cols(df, frm, frm_cols=[], verbose=True):
     return cols_from
 
 
-def convert_gene(df, frm, to, species='human', frm_cols=[], verbose=True):
+def convert_gene(df, frm, to, species='human', frm_cols=[], verbose=True,
+                 bad_genes_col=False):
     """Convert gene names
 
     Convert T-cell receptor (TCR) gene names between the IMGT, 10X, and Adaptive
@@ -215,6 +216,9 @@ def convert_gene(df, frm, to, species='human', frm_cols=[], verbose=True):
     new_genes = {}
     bad_genes = []
 
+    if bad_genes_col:
+        bad_df = pd.DataFrame(index=df.index)
+
     for col in cols_from:
         if col in df.columns:
             good_genes = (
@@ -222,6 +226,9 @@ def convert_gene(df, frm, to, species='human', frm_cols=[], verbose=True):
                 .merge(lookup[[frm, to]], how='left', left_on=col, right_on=frm)
                 .drop(columns=frm)
             )
+            if bad_genes_col:
+                # Keep bad genes and make good genes NA
+                bad_df[col] = df[col].where(good_genes[to].isna(), pd.NA)
             # Note genes where the merge produced an NA on the 'to' format side
             new_bad_genes = good_genes[good_genes[to].isna()][col].dropna().tolist()
             # We don't expect the entire column of genes to be empty.
@@ -247,6 +254,12 @@ def convert_gene(df, frm, to, species='human', frm_cols=[], verbose=True):
         out_df[col] = new_genes[col][to].values
         # Replace NoData and np.nan with pd.NA
         out_df[col] = out_df[col].replace('NoData', pd.NA)
+
+    if bad_genes_col:
+        # Append the column of bad genes
+        out_df['bad_genes'] = bad_df.agg(
+            lambda row: ','.join(row.dropna().astype(str)), axis=1
+            ).replace('', pd.NA)
 
     return out_df
 

--- a/tcrconvert/convert.py
+++ b/tcrconvert/convert.py
@@ -261,6 +261,9 @@ def convert_gene(df, frm, to, species='human', frm_cols=[], verbose=True,
             lambda row: ','.join(row.dropna().astype(str)), axis=1
             ).replace('', pd.NA)
 
+    # Ensure all NAs are the same type
+    out_df = out_df.fillna(pd.NA)
+
     return out_df
 
 

--- a/tcrconvert/convert.py
+++ b/tcrconvert/convert.py
@@ -128,8 +128,9 @@ def which_frm_cols(df, frm, frm_cols=[], verbose=True):
     return cols_from
 
 
-def convert_gene(df, frm, to, species='human', frm_cols=[], verbose=True,
-                 bad_genes_col=False):
+def convert_gene(
+    df, frm, to, species='human', frm_cols=[], verbose=True, bad_genes_col=False
+):
     """Convert gene names
 
     Convert T-cell receptor (TCR) gene names between the IMGT, 10X, and Adaptive
@@ -261,7 +262,7 @@ def convert_gene(df, frm, to, species='human', frm_cols=[], verbose=True,
         # Append the column of bad genes
         out_df['bad_genes'] = bad_df.agg(
             lambda row: ','.join(row.dropna().astype(str)), axis=1
-            ).replace('', pd.NA)
+        ).replace('', pd.NA)
 
     # Ensure all NAs are the same type
     out_df = out_df.fillna(pd.NA)

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -338,3 +338,54 @@ def test_convert_gene_verbose(caplog):
             'These genes are not in IMGT for this species and will be replaced with NA'
             in caplog.text
         )
+
+def test_convert_gene_bad_genes_col():
+    # Test dataframe with some genes that won't convert
+    tenx_df_bad = pd.DataFrame(
+        {
+            'v_gene': ['TRAV12-1', 'BAD_V_GENE'],
+            'd_gene': [pd.NA, 'TRBD1'],
+            'j_gene': ['TRAJ16', 'BAD_J_GENE'],
+            'c_gene': ['BAD_C_GENE', 'TRBC2'],
+            'cdr3': ['CAVLIF', 'CASSGF'],
+        }
+    )
+
+    # Expected output with bad_genes_col=True
+    expected_with_bad = pd.DataFrame(
+        {
+            'v_gene': ['TRAV12-1*01', pd.NA],
+            'd_gene': [pd.NA, 'TRBD1*01'],
+            'j_gene': ['TRAJ16*01', pd.NA],
+            'c_gene': [pd.NA, 'TRBC2*01'],
+            'cdr3': ['CAVLIF', 'CASSGF'],
+            'bad_genes': ['BAD_C_GENE', 'BAD_V_GENE,BAD_J_GENE'],
+        }
+    )
+
+    # Expected output with bad_genes_col=False
+    expected_without_bad = pd.DataFrame(
+        {
+            'v_gene': ['TRAV12-1*01', pd.NA],
+            'd_gene': [pd.NA, 'TRBD1*01'],
+            'j_gene': ['TRAJ16*01', pd.NA],
+            'c_gene': [pd.NA, 'TRBC2*01'],
+            'cdr3': ['CAVLIF', 'CASSGF'],
+        }
+    )
+
+    # Test with bad_genes_col=True
+    result_with = convert.convert_gene(tenx_df_bad, 'tenx', 'imgt', bad_genes_col=True)
+    test_result_with = result_with.fillna('blank')
+    test_expected_with = expected_with_bad.fillna('blank')
+    pd.testing.assert_frame_equal(test_result_with, test_expected_with)
+
+    # Test with bad_genes_col=False
+    result_without = convert.convert_gene(tenx_df_bad, 'tenx', 'imgt', bad_genes_col=False)
+    test_result_without = result_without.fillna('blank')
+    test_expected_without = expected_without_bad.fillna('blank')
+    pd.testing.assert_frame_equal(test_result_without, test_expected_without)
+
+    # Test that all genes convert successfully - bad_genes should be NA
+    result_good = convert.convert_gene(tenx_df, 'tenx', 'imgt', bad_genes_col=True)
+    assert result_good['bad_genes'].isna().all()

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -339,6 +339,7 @@ def test_convert_gene_verbose(caplog):
             in caplog.text
         )
 
+
 def test_convert_gene_bad_genes_col():
     # Test dataframe with some genes that won't convert
     tenx_df_bad = pd.DataFrame(
@@ -381,7 +382,9 @@ def test_convert_gene_bad_genes_col():
     pd.testing.assert_frame_equal(test_result_with, test_expected_with)
 
     # Test with bad_genes_col=False
-    result_without = convert.convert_gene(tenx_df_bad, 'tenx', 'imgt', bad_genes_col=False)
+    result_without = convert.convert_gene(
+        tenx_df_bad, 'tenx', 'imgt', bad_genes_col=False
+    )
     test_result_without = result_without.fillna('blank')
     test_expected_without = expected_without_bad.fillna('blank')
     pd.testing.assert_frame_equal(test_result_without, test_expected_without)


### PR DESCRIPTION
This PR adds a parameter (`bad_genes_col`) to the `convert_gene()` function that allows a user to retain unconvertable gene names in an extra column (`bad_genes`) that gets appended to the output data frame.

I added a test for this and documented within the docstring and FAQ page.